### PR TITLE
feat: make opentelemetry and sentry optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /bazel-*
 /MODULE.bazel.lock
+/.bazelrc.user

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,14 @@ pub use tracing::*;
 pub fn sentry_init() -> sentry::ClientInitGuard {
     sentry::init(sentry::ClientOptions {
         dsn: env::var("SENTRY_DSN").ok().and_then(|dsn| dsn.parse().ok()),
-        environment: env::var("ENVIRONMENT").map(Cow::Owned).ok(),
+        environment: env::var("ENVIRONMENT")
+            .ok()
+            .and_then(|name| match name.as_str() {
+                "test" => Some("testing"),
+                "prod" => Some("production"),
+                _ => None,
+            })
+            .map(Cow::Borrowed),
         traces_sample_rate: 0.0,
         release: sentry::release_name!(),
         attach_stacktrace: true,


### PR DESCRIPTION
- Update sentry init to map environment correctly
- Update OpenTelemetry to allow disabling the layer with environment variable